### PR TITLE
Fix canvas scaling on resize

### DIFF
--- a/mobile_fishing_game.html
+++ b/mobile_fishing_game.html
@@ -31,7 +31,7 @@ function resize(){
   const rect = canvas.getBoundingClientRect();
   canvas.width  = rect.width  * dpr;
   canvas.height = rect.height * dpr;
-  ctx.scale(dpr,dpr);
+  ctx.setTransform(dpr,0,0,dpr,0,0);
 }
 resize();
 window.addEventListener('resize',resize);


### PR DESCRIPTION
## Summary
- use `setTransform` when resizing the canvas so scale doesn't stack

## Testing
- `no tests`

------
https://chatgpt.com/codex/tasks/task_e_685c0df50b58832f8daada3540a012c2